### PR TITLE
Add more specific license type to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "licenses": [
     {
-      "type": "Apache",
+      "type": "Apache-2.0",
       "url": "https://github.com/palantir/grunt-tslint/blob/master/LICENSE.txt"
     }
   ],


### PR DESCRIPTION
This allows automatic tools, such as license-checker ( https://github.com/davglass/license-checker ) to work better.
