### PR TITLE
main loop async for 'streaming' output

### DIFF
--- a/tasks/tslint.js
+++ b/tasks/tslint.js
@@ -24,10 +24,10 @@ module.exports = function(grunt) {
     var options = this.options({
       formatter: "prose"
     });
+    var done = this.async();
 
-    var retValue = true;
-    // Iterate over all specified file groups.
-    this.filesSrc.forEach(function(filepath) {
+    // Iterate over all specified file groups, async for 'streaming' output on large projects
+    grunt.util.async.reduce(this.filesSrc, true, function(success, filepath, callback) {
       if (!grunt.file.exists(filepath)) {
         grunt.log.warn('Source file "' + filepath + '" not found.');
       } else {
@@ -42,11 +42,23 @@ module.exports = function(grunt) {
               grunt.log.error(line);
             }
           });
-          retValue = false;
+          success = false;
         }
       }
+      // Using setTimout as process.nextTick() doesn't flush
+      setTimeout(function() {
+        callback(null, success);
+      }, 1);
+
+    }, function(err, success) {
+        if (err) {
+            done(err);
+        } else if (!success) {
+            done(false);
+        } else {
+            done();
+        }
     });
-    return retValue;
   });
 
 };


### PR DESCRIPTION
When linting large projects the grunt task can seem to hang as the linting loop is fully synchronous and node would buffer the output (at least on windows it does)

This PR changes the loop to use async() and adds a 1ms timeout, this breaks up the node event-loop and allows it to flush output per file. 

Of course I tried process.nextTick() instead of setTimeout, but it is not the 100% same behaviour, for example in WebStorm IDE (with grunt as External Tool) the view doesn't stream.

Overall processing time is still same, but it feels a lot smoother as the results come streaming in now.
- using async.reduce()
- setTimeout(f, 0) is to make sure output actually streams (tested in IntelliJ > Run Tools), as process.nextTick doesn't always flush buffer
