### PR TITLE
Make tslint a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,14 @@
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies": {
-    "tslint": "1.0.1"
-  },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-clean": "~0.4.0",
     "grunt": "~0.4.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": "~0.4.1",
+    "tslint": "^1.0.1"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Make tslint a peer dependency so it can be overridden, also make it auto update.  If someone needs an older version they can just force it over themselves.
@ashwinr, This should make it more configurable going forward.  I use 1.0.1 as the base version because it should be interface compatible.