### PR TITLE
fix outputFile for multiple source files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
             errors: {
                 options: {
                     configuration: "tslint.json",
-                    force: false
+                    force: true
                 },
                 files: {
                     src: [
@@ -63,16 +63,10 @@ module.exports = function(grunt) {
     // actually load this plugin's task(s)
     grunt.loadTasks("tasks");
 
-    grunt.registerTask("test", ["tslint", "mochaTest"]);
-
     // by default, lint and run all tests
     grunt.registerTask("default", ["jshint", "test"]);
 
-    // actually load this plugin's task(s)
-    grunt.loadTasks("tasks");
+    // run unit tests
+    grunt.registerTask("test", ["mochaTest"]);
 
-    grunt.registerTask("test", ["tslint"]);
-
-    // by default, lint and run all tests
-    grunt.registerTask("default", ["jshint", "test"]);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,9 +16,10 @@
 
 "use strict";
 
-module.exports = function (grunt) {
+module.exports = function(grunt) {
     grunt.loadNpmTasks("grunt-contrib-jshint");
     grunt.loadNpmTasks("grunt-contrib-clean");
+    grunt.loadNpmTasks('grunt-mocha-test');
 
     grunt.initConfig({
         jshint: {
@@ -45,8 +46,27 @@ module.exports = function (grunt) {
                     ]
                 }
             }
+        },
+
+        mochaTest: {
+            test: {
+                options: {
+                    reporter: 'spec',
+                    quiet: false,
+                    log: true
+                },
+                src: ["test/tasks/**/*.js"]
+            }
         }
     });
+
+    // actually load this plugin's task(s)
+    grunt.loadTasks("tasks");
+
+    grunt.registerTask("test", ["tslint", "mochaTest"]);
+
+    // by default, lint and run all tests
+    grunt.registerTask("default", ["jshint", "test"]);
 
     // actually load this plugin's task(s)
     grunt.loadTasks("tasks");

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "cover-child-process": "^0.1.5",
     "grunt-cli": "^0.1.13",
     "grunt-mocha-test": "^0.12.7",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.4.3"
   },
   "peerDependencies": {
     "grunt": ">=0.4.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,12 @@
     "grunt-contrib-clean": "~1.0.0",
     "grunt-contrib-jshint": "~1.0.0",
     "tslint": "latest",
-    "typescript": "latest"
+    "typescript": "latest",
+    "chai": "^3.4.0",
+    "cover-child-process": "^0.1.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-mocha-test": "^0.12.7",
+    "mocha": "^2.3.3"
   },
   "peerDependencies": {
     "grunt": ">=0.4.5",

--- a/tasks/tslint.js
+++ b/tasks/tslint.js
@@ -33,6 +33,8 @@ module.exports = function (grunt) {
 
         var done = this.async();
         var failed = 0;
+        var outputFile = options.outputFile;
+        var appendToOutput = options.appendToOutput;
 
         // Iterate over all specified file groups, async for 'streaming' output on large projects
         grunt.util.async.reduce(this.filesSrc, true, function (success, filepath, callback) {
@@ -51,8 +53,6 @@ module.exports = function (grunt) {
 
                 if (result.failureCount > 0) {
                     var outputString = "";
-                    var outputFile = options.outputFile;
-                    var appendToOutput = options.appendToOutput;
 
                     failed += result.failureCount;
 

--- a/tasks/tslint.js
+++ b/tasks/tslint.js
@@ -29,10 +29,11 @@ module.exports = function (grunt) {
         });
 
         var specifiedConfiguration = options.configuration;
-        var force = options.force;
-
         var done = this.async();
         var failed = 0;
+        var results = [];
+
+        var force = options.force;
         var outputFile = options.outputFile;
         var appendToOutput = options.appendToOutput;
 
@@ -65,6 +66,7 @@ module.exports = function (grunt) {
                     }
                     result.output.split("\n").forEach(function (line) {
                         if (line !== "") {
+                            results = results.concat((options.formatter.toLowerCase() === 'json') ? JSON.parse(line) : line);
                             if (outputFile != null) {
                                 outputString += line + "\n";
                             } else {
@@ -74,6 +76,7 @@ module.exports = function (grunt) {
                     });
                     if (outputFile != null) {
                         grunt.file.write(outputFile, outputString);
+                        appendToOutput = true;
                     }
                     success = false;
                 }
@@ -98,5 +101,6 @@ module.exports = function (grunt) {
                 done(force);
             }
         }.bind(this));
+
     });
 };

--- a/test/scenarios/multi-error-files/Gruntfile.js
+++ b/test/scenarios/multi-error-files/Gruntfile.js
@@ -1,0 +1,37 @@
+"use strict";
+
+module.exports = function(grunt) {
+
+	var cwd = process.cwd();
+	grunt.file.setBase("../../..");
+	grunt.loadTasks(".");
+	grunt.loadNpmTasks("grunt-contrib-jshint");
+	grunt.file.setBase(cwd);
+
+	grunt.initConfig({
+
+		tslint: {
+			stdout: {
+				options: {
+					configuration: grunt.file.readJSON("tslint.json")
+				},
+				files: {
+					src: ["*.ts"]
+				}
+			},
+			file: {
+				options: {
+					configuration: grunt.file.readJSON("tslint.json"),
+					outputFile: 'tmp/outputFile'
+				},
+				files: {
+					src: ["*.ts"]
+				}
+			}
+		}
+
+	});
+
+	grunt.registerTask("default", ["tslint"]);
+
+};

--- a/test/scenarios/multi-error-files/errorFile1.ts
+++ b/test/scenarios/multi-error-files/errorFile1.ts
@@ -1,0 +1,1 @@
+var Xx = 'abcd';

--- a/test/scenarios/multi-error-files/errorFile2.ts
+++ b/test/scenarios/multi-error-files/errorFile2.ts
@@ -1,0 +1,8 @@
+class A {
+    constructor() {
+        for (var i = 0; i < 10; ++i) {
+            debugger;
+            eval("something");
+        }
+    }
+}

--- a/test/scenarios/multi-error-files/tslint.json
+++ b/test/scenarios/multi-error-files/tslint.json
@@ -1,0 +1,48 @@
+{
+  "rules": {
+    "class-name": true,
+    "curly": true,
+    "eofline": true,
+    "forin": true,
+    "indent": [true, 4],
+    "label-position": true,
+    "label-undefined": true,
+    "max-line-length": [true, 140],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-console": [true,
+        "debug",
+        "info",
+        "time",
+        "timeEnd",
+        "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-key": true,
+    "no-duplicate-variable": true,
+    "no-empty": true,
+    "no-eval": true,
+    "no-string-literal": true,
+    "no-trailing-whitespace": true,
+    "no-unreachable": true,
+    "one-line": [true,
+        "check-open-brace",
+        "check-catch",
+        "check-else",
+        "check-whitespace"
+    ],
+    "quotemark": [true, "double"],
+    "radix": true,
+    "semicolon": true,
+    "triple-equals": [true, "allow-null-check"],
+    "variable-name": false,
+    "whitespace": [true,
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type"
+    ]
+  }
+}

--- a/test/scenarios/single-error-file/Gruntfile.js
+++ b/test/scenarios/single-error-file/Gruntfile.js
@@ -1,0 +1,28 @@
+"use strict";
+
+module.exports = function(grunt) {
+
+	var cwd = process.cwd();
+	grunt.file.setBase("../../..");
+	grunt.loadTasks(".");
+	grunt.loadNpmTasks("grunt-contrib-jshint");
+	grunt.file.setBase(cwd);
+
+	grunt.initConfig({
+
+		tslint: {
+			default: {
+				options: {
+					configuration: grunt.file.readJSON("tslint.json")
+				},
+				files: {
+					src: ["errorFile.ts"]
+				}
+			}
+		}
+
+	});
+
+	grunt.registerTask("default", ["tslint"]);
+
+};

--- a/test/scenarios/single-error-file/errorFile.ts
+++ b/test/scenarios/single-error-file/errorFile.ts
@@ -1,0 +1,1 @@
+var foo = 'bar'

--- a/test/scenarios/single-error-file/tslint.json
+++ b/test/scenarios/single-error-file/tslint.json
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"semicolon": true
+	}
+}

--- a/test/scenarios/single-valid-file/Gruntfile.js
+++ b/test/scenarios/single-valid-file/Gruntfile.js
@@ -1,0 +1,28 @@
+"use strict";
+
+module.exports = function(grunt) {
+
+	var cwd = process.cwd();
+	grunt.file.setBase("../../..");
+	grunt.loadTasks(".");
+	grunt.loadNpmTasks("grunt-contrib-jshint");
+	grunt.file.setBase(cwd);
+
+	grunt.initConfig({
+
+		tslint: {
+			default: {
+				options: {
+					configuration: grunt.file.readJSON("tslint.json")
+				},
+				files: {
+					src: ["validFile.ts"]
+				}
+			}
+		}
+
+	});
+
+	grunt.registerTask("default", ["tslint"]);
+
+};

--- a/test/scenarios/single-valid-file/tslint.json
+++ b/test/scenarios/single-valid-file/tslint.json
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"semicolon": true
+	}
+}

--- a/test/scenarios/single-valid-file/validFile.ts
+++ b/test/scenarios/single-valid-file/validFile.ts
@@ -1,0 +1,1 @@
+var foo = 'bar';

--- a/test/tasks/basic.js
+++ b/test/tasks/basic.js
@@ -1,0 +1,35 @@
+var expect = require('chai').expect;
+var path = require('path');
+var ChildProcess = require('cover-child-process').ChildProcess;
+var Blanket = require('cover-child-process').Blanket;
+var childProcess = new ChildProcess(new Blanket());
+
+var gruntExec = 'node ' + path.resolve('node_modules/grunt-cli/bin/grunt --no-color');
+
+var execGrunt = function(parameters, callback) {
+  parameters = parameters || [];
+  childProcess.exec([gruntExec].concat(parameters).join(' '), {
+  	cwd: path.resolve(__dirname)
+  }, callback);
+};
+
+var fixture = function(file, scenario) {
+	var dir = path.join(__dirname, '../../test', (scenario ? 'scenarios/' + scenario : 'fixtures'));
+	return path.join(dir, file);
+};
+
+describe('grunt-tslint on a single file', function() {
+	it('should find errors in single invalid .ts file', function(done) {
+		execGrunt('--gruntfile ' + fixture('Gruntfile.js', 'single-error-file'), function(error, stdout, stderr) {
+			expect(stdout).to.match(/1 error in 1 file/);
+			done();
+		});
+	});
+
+	it('should not find errors in a single valid .ts file', function(done) {
+		execGrunt('--gruntfile ' + fixture('Gruntfile.js', 'single-valid-file'), function(error, stdout, stderr) {
+			expect(stdout).to.match(/1 file lint free/);
+			done();
+		});
+	});
+});


### PR DESCRIPTION
- introduces Unit-Tests using Mocha and Chai.expect
- fixes handling of multiple files writing to an outputFile

#### Description
When running on multiple source files reporting to a shared `outputFile`, only the output of the latest file was stored, because the file was deleted on each iteration.

```javascript
tslint: {
	stdout: {
		options: {
			configuration: grunt.file.readJSON("tslint.json")
		},
		files: {
			src: ["*.ts"]
		}
	},
	file: {
		options: {
			configuration: grunt.file.readJSON("tslint.json"),
			outputFile: '/tmp/outputFile'
		},
		files: {
			src: ["*.ts"]
		}
	}
}
```

Expected Result: 
- the errors written to `tmp/outputFile` are the same as printed to `stdout`

#### Fix
After the report of the first queued file was written, the `appendToOutput` option is set to true, so that the further output is appended to the file.