### PR TITLE
support configuration as file path

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
     tslint: {
       errors: {
         options: {
-          configuration: grunt.file.readJSON("tslint.json")
+          configuration: "tslint.json"
         },
         files: {
           src: [

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A JSON configuration object passed into tslint.
 grunt.initConfig({
   tslint: {
     options: {
-      configuration: grunt.file.readJSON("tslint.json")
+      configuration: "tslint.json"
     },
     files: {
       src: ['src/file1.ts', 'src/file2.ts']

--- a/tasks/tslint.js
+++ b/tasks/tslint.js
@@ -26,9 +26,11 @@ module.exports = function(grunt) {
       outputFile: null,
       appendToOutput: false
     });
+    if (typeof options.configuration === "string") {
+        options.configuration = grunt.file.readJSON( options.configuration );
+    }
     var done = this.async();
     var failed = 0;
-
     // Iterate over all specified file groups, async for 'streaming' output on large projects
     grunt.util.async.reduce(this.filesSrc, true, function(success, filepath, callback) {
       if (!grunt.file.exists(filepath)) {


### PR DESCRIPTION
This allows configuration to be specified as a file path.  If the configuration option is a string, it is assumed to be a file path, otherwise it is handled as a configuration object (as it was previously).

I needed this because I am generating a Gruntfile programmatically through a [Yeoman](/yeoman/yo) generator, which uses [gruntfile-editor](/SBoudrias/gruntfile-editor).  I'm serializing the `tslint` task configuration with JSON, which does not allow identifiers, functions, or invocations.  Therefore, it is not feasible to inline a `grunt.file.readJSON` call into my task configuration.

I could inline the configuration JSON into the property but that would bloat my task configuration.  This helps keep grunt task configurations both concise and _declarative_ (as opposed to function invocations which are _imperative_).  It also increases compatibility with external utilities which don't support imperative syntax.

