### PR TITLE
Minor change to MSBuild formatter to allow the error messages in a format Visual Studio can understand (not prefixed with >>) so that error messages are linked.

### DIFF
--- a/tasks/tslint.js
+++ b/tasks/tslint.js
@@ -80,6 +80,8 @@ module.exports = function (grunt) {
                             );
                             if (outputFile != null) {
                                 outputString += line + "\n";
+                            } else if (options.formatter.toLowerCase() === "msbuild") {
+                                grunt.log.writeln(line['red']);
                             } else {
                                 grunt.log.error(line);
                             }


### PR DESCRIPTION
This is to allow the error messages in a format Visual Studio can understand (not prefixed with >>) so that error messages are linked to the file in question. This is accomplished by not using the Grunt error output, instead performing a log.writeln (with the colour red) - to ensure that the messages still are prominent.