### PR TITLE
Fix task failure upon warnings only

### DIFF
--- a/tasks/tslint.js
+++ b/tasks/tslint.js
@@ -111,7 +111,7 @@ module.exports = function (grunt) {
         }, function (err, success) {
             if (err) {
                 done(err);
-            } else if (success && warnings === 0) {
+            } else if (success) {
                 var okMessage;
                 if (warnings === 0) {
                     okMessage = this.filesSrc.length + " " +


### PR DESCRIPTION
See issue #71.

If there were warnings, what appeared to be an obvious control flow error resulted in the task failing, rather than succeeding and printing out the warnings.

This PR removes a check of the warning count that should see control flow as the implementation suggests it should.