### PR TITLE
Allow type checking (fixes #67)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
                 options: {
                     configuration: "tslint.json",
                     force: true,
+                    typeCheck: true,
                 },
                 files: {
                     src: [

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ grunt.initConfig({
 * `options.configuration: Object | string` - A TSLint configuration; can either be a JSON configuration object or a path to a tslint.json config file.
 * `options.force: boolean` - If `true`, the task will suceed even if lint failures are found. Defaults to `false`.
 * `options.fix: boolean` - If `true`, fixes linting errors for select rules. This may overwrite linted files. Defaults to `false`.
+* `options.typeCheck: boolean` - If `true`, enables [type checking](http://palantir.github.io/tslint/usage/type-checking/) while linting. Defaults to `false`.
 
 ### Usage Example
 

--- a/tasks/tslint.js
+++ b/tasks/tslint.js
@@ -19,6 +19,7 @@
 /* eslint-disable no-invalid-this, no-use-before-define */
 module.exports = function (grunt) {
     var Linter = require("tslint");
+    var ts = require("typescript");
 
     grunt.registerMultiTask("tslint", "A linter for TypeScript.", function () {
         var options = this.options({
@@ -29,6 +30,7 @@ module.exports = function (grunt) {
             appendToOutput: false,
             force: false,
             fix: false,
+            typeCheck: false,
         });
 
         var specifiedConfiguration = options.configuration;
@@ -62,7 +64,9 @@ module.exports = function (grunt) {
                     rulesDirectory: options.rulesDirectory
                 };
 
-                var linter = new Linter.Linter(lintOptions);
+                // eslint-disable-next-line new-cap
+                var program = options.typeCheck ? new ts.createProgram([filepath], {}) : undefined;
+                var linter = new Linter.Linter(lintOptions, program);
                 var contents = grunt.file.read(filepath);
                 linter.lint(filepath, contents, configuration);
                 var result = linter.getResult();

--- a/test/scenarios/requires-type-checking/Gruntfile.js
+++ b/test/scenarios/requires-type-checking/Gruntfile.js
@@ -1,0 +1,30 @@
+"use strict";
+
+module.exports = function(grunt) {
+
+    var cwd = process.cwd();
+    grunt.file.setBase("../../..");
+    grunt.loadTasks(".");
+    grunt.loadNpmTasks("grunt-contrib-jshint");
+    grunt.file.setBase(cwd);
+
+    grunt.initConfig({
+
+        tslint: {
+            default: {
+                options: {
+                    // load using file name
+                    configuration: "tslint.json",
+                    typeCheck: true
+                },
+                files: {
+                    src: ["errorFileWithTypeChecking.ts"]
+                }
+            }
+        }
+
+    });
+
+    grunt.registerTask("default", ["tslint"]);
+
+};

--- a/test/scenarios/requires-type-checking/errorFileWithTypeChecking.ts
+++ b/test/scenarios/requires-type-checking/errorFileWithTypeChecking.ts
@@ -1,0 +1,4 @@
+const str = "testing";
+if (str) {
+    console.log("should result in linting error");
+}

--- a/test/scenarios/requires-type-checking/tslint.json
+++ b/test/scenarios/requires-type-checking/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "strict-boolean-expressions": true
+  }
+}

--- a/test/tasks/basic.js
+++ b/test/tasks/basic.js
@@ -35,6 +35,13 @@ describe('grunt-tslint on a single file', function() {
             done();
         });
     });
+    
+    it('should find errors in single invalid .ts file that requires type checking', function(done) {
+        execGrunt('--gruntfile ' + fixture('Gruntfile.js', 'requires-type-checking'), function(error, stdout, stderr) {
+            expect(stdout).to.match(/1 error and 0 warnings in 1 file/);
+            done();
+        });
+    });
 });
 
 describe('grunt-tslint on multiple files', function() {


### PR DESCRIPTION
  * Providing `typeCheck: true` in the options for the task will create
    a TypeScript program instance to be used during linting.

fixes #67 