### PR TITLE
Allow type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ grunt.initConfig({
 ### Options
 
 * `options.configuration: Object | string` - A TSLint configuration; can either be a JSON configuration object or a path to a tslint.json config file.
+* `options.project: string` - `tsconfig.json` file location. If provided type checking will be enabled. 
 * `options.force: boolean` - If `true`, the task will suceed even if lint failures are found. Defaults to `false`.
 * `options.fix: boolean` - If `true`, fixes linting errors for select rules. This may overwrite linted files. Defaults to `false`.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-tslint",
   "description": "Grunt plugin for TypeScript Linter.",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "homepage": "https://github.com/palantir/grunt-tslint",
   "author": {
     "name": "Palantir Technologies, Inc."

--- a/tasks/tslint.js
+++ b/tasks/tslint.js
@@ -23,6 +23,7 @@ module.exports = function (grunt) {
     grunt.registerMultiTask("tslint", "A linter for TypeScript.", function () {
         var options = this.options({
             configuration: null,
+            project: null,
             formatter: "prose",
             outputFile: null,
             outputReport: null,
@@ -62,7 +63,11 @@ module.exports = function (grunt) {
                     rulesDirectory: options.rulesDirectory,
                 };
 
-                var linter = new Linter.Linter(lintOptions);
+                var program;
+                if (options.project != null) {
+                    program = Linter.Linter.createProgram(options.project);
+                }
+                var linter = new Linter.Linter(lintOptions, program);
                 var contents = grunt.file.read(filepath);
                 linter.lint(filepath, contents, configuration);
                 var result = linter.getResult();

--- a/tasks/tslint.js
+++ b/tasks/tslint.js
@@ -42,6 +42,11 @@ module.exports = function (grunt) {
         var outputFile = options.outputFile;
         var appendToOutput = options.appendToOutput;
 
+        var program;
+        if (options.project != null) {
+            program = Linter.Linter.createProgram(options.project);
+        }
+
         // Iterate over all specified file groups, async for 'streaming' output on large projects
         grunt.util.async.reduce(this.filesSrc, true, function (success, filepath, callback) {
             if (!grunt.file.exists(filepath)) {
@@ -63,10 +68,6 @@ module.exports = function (grunt) {
                     rulesDirectory: options.rulesDirectory,
                 };
 
-                var program;
-                if (options.project != null) {
-                    program = Linter.Linter.createProgram(options.project);
-                }
                 var linter = new Linter.Linter(lintOptions, program);
                 var contents = grunt.file.read(filepath);
                 linter.lint(filepath, contents, configuration);

--- a/test/scenarios/requires-type-checking/Gruntfile.js
+++ b/test/scenarios/requires-type-checking/Gruntfile.js
@@ -1,0 +1,30 @@
+"use strict";
+
+module.exports = function(grunt) {
+
+    var cwd = process.cwd();
+    grunt.file.setBase("../../..");
+    grunt.loadTasks(".");
+    grunt.loadNpmTasks("grunt-contrib-jshint");
+    grunt.file.setBase(cwd);
+
+    grunt.initConfig({
+
+        tslint: {
+            default: {
+                options: {
+                    // load using file name
+                    configuration: "tslint.json",
+                    project: "tsconfig.json"
+                },
+                files: {
+                    src: ["errorFileWithTypeChecking.ts"]
+                }
+            }
+        }
+
+    });
+
+    grunt.registerTask("default", ["tslint"]);
+
+};

--- a/test/scenarios/requires-type-checking/errorFileWithTypeChecking.ts
+++ b/test/scenarios/requires-type-checking/errorFileWithTypeChecking.ts
@@ -1,0 +1,4 @@
+const str = "testing";
+if (str) {
+	console.log("should result in linting error");
+}

--- a/test/scenarios/requires-type-checking/tsconfig.json
+++ b/test/scenarios/requires-type-checking/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "target": "es5",
+        "noImplicitAny": true,
+        "removeComments": true,
+        "preserveConstEnums": true,
+        "sourceMap": true
+    },
+    "files": [
+        "errorFileWithTypeChecking.ts"
+    ]
+}

--- a/test/scenarios/requires-type-checking/tslint.json
+++ b/test/scenarios/requires-type-checking/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "strict-boolean-expressions": true
+  }
+}

--- a/test/tasks/basic.js
+++ b/test/tasks/basic.js
@@ -35,6 +35,13 @@ describe('grunt-tslint on a single file', function() {
             done();
         });
     });
+
+    it('should find errors in single invalid .ts file that requires type checking', function(done) {
+        execGrunt('--gruntfile ' + fixture('Gruntfile.js', 'requires-type-checking'), function(error, stdout, stderr) {
+            expect(stdout).to.match(/1 error and 0 warnings in 1 file/);
+            done();
+        });
+    });
 });
 
 describe('grunt-tslint on multiple files', function() {


### PR DESCRIPTION
Fixes #67. As there seems to be no development in #73...

Added option `project`. It is the equivalent to tslint `--project` argument. Uses `Linter.createProgram` to create program for type checking.